### PR TITLE
Add zookeeper/ prefix to the include

### DIFF
--- a/src/Zookeeper.hsc
+++ b/src/Zookeeper.hsc
@@ -134,7 +134,7 @@ type VoidPtr = Ptr CBlob
 type AclsPtr = Ptr CBlob
 type StatPtr = Ptr CBlob
 
-#include <zookeeper.h>
+#include <zookeeper/zookeeper.h>
 
 foreign import ccall "wrapper"
   wrapWatcherImpl :: WatcherImpl -> IO (FunPtr WatcherImpl)


### PR DESCRIPTION
zookeeper-mt headers are installed in /usr/include/zookeeper on Ubuntu and OSX
Homebrew
